### PR TITLE
Ignore unquoted fonts.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,15 @@ const RE_DOUBLE_COUTE = /\\"/g;
 const RE_SPACE = /[ ]+/g;
 const RE_UNICODE = /\\\\([\d\w]{4})/g;
 module.exports = function(source) {
-    // console.log('font-family-unescape-loader');
-    // console.log(source);
+
     source = source.replace(RE_FONT_FAMILY, (str, fontNames) => {
         const strFontNames = fontNames.replace(RE_DOUBLE_COUTE, "'").replace(RE_FONT_NAMES, (match, fontName, sep) => {
-            return `'${fontName.replace(RE_SPACE, ' ').replace(RE_UNICODE, (m, unicode) => String.fromCharCode(parseInt(unicode, 16)))}'${sep || ''}`;
+            if(match.includes("'"))
+                return `'${fontName.replace(RE_SPACE, ' ').replace(RE_UNICODE, (m, unicode) => String.fromCharCode(parseInt(unicode, 16)))}'${sep || ''}`;
+            return match;
         });
         return `font-family: ${strFontNames};`;
     });
-    // console.log(source);
+
     return source;
 }


### PR DESCRIPTION
This PR makes this loader ignore the fonts which originally NOT been quoted and keep what them were.

Original:
```
font-family: 'Avenir', Helvetica, Arial, "微软雅黑", sans-serif;
```
Output (Before change):
```
font-family: 'Avenir', 'Helvetica', 'Arial', '微软雅黑', 'sans-serif';
```
Output (After change):
```
font-family: 'Avenir', Helvetica, Arial, '微软雅黑', sans-serif;
```

